### PR TITLE
v1.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyportfolioopt" %}
-{% set version = "1.5.6" %}
+{% set version = "1.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7e94f41c84fb5865c7a64de995a3ba580188f3ba494f6dfbc02721b5de323f6e
+  sha256: de5ea1914d6ca6bc83c54a954be123bd9c770275c769d1d70fb8760092cd5e9b
 
 build:
   number: 0
@@ -18,18 +18,19 @@ requirements:
   host:
     - pip
     - python
-    - poetry-core >=1.0.0
+    - setuptools
   run:
     - python
     - cvxpy >=1.1.19
-    - numpy >=1.26.0
-    - pandas >=0.19
+    - numpy >=1.26.0,<3.0.0
+    - pandas >=1.0.0,<4.0.0
+    - scikit-learn >=0.24.1
+    - scikit-base <0.14.0
     - scipy >=1.3
   run_constrained:
     - matplotlib-base >=3.2
-    - scikit-learn >=0.24.1
-    - ecos >=2.0.14,<3.0.0
-    - plotly >=5.0.0,<6.0.0
+    - ecos >=2.0.14,<2.1
+    - plotly >=5.0.0,<7.0.0
 
 test:
   # Test folder is not available in PYPI tarball, and there is no release on github to get them
@@ -46,7 +47,7 @@ about:
   home: https://github.com/robertmartin8/PyPortfolioOpt
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: Financial portfolio optimization in python
   description: |
     PyPortfolioOpt is a library that implements portfolio optimization methods, 


### PR DESCRIPTION
pyportfolioopt v1.6.0

**Destination channel:**  defaults

### Links

- [PKG-12083](https://anaconda.atlassian.net/browse/PKG-12083) 
- [Upstream repository](https://github.com/PyPortfolio/PyPortfolioOpt/tree/v1.6.0)
- [Upstream changelog/diff](https://github.com/PyPortfolio/PyPortfolioOpt/releases/tag/v1.6.0)

### Explanation of changes:

- Bump version and SHA
- Update pinnings
- Fix license to match upstream

[PKG-12083]: https://anaconda.atlassian.net/browse/PKG-12083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ